### PR TITLE
Update for 6.5 installer URLs

### DIFF
--- a/install-racket.sh
+++ b/install-racket.sh
@@ -11,8 +11,10 @@ elif [[ "$RACKET_VERSION" = "RELEASE" ]]; then
     URL="http://pre-release.racket-lang.org/installers/racket-current-x86_64-linux-ubuntu-precise.sh"
 elif [[ "$RACKET_VERSION" = 5.9* ]]; then
     URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket-${RACKET_VERSION}-x86_64-linux-ubuntu-quantal.sh"
-elif [[ "$RACKET_VERSION" = 6.* ]]; then
+elif [[ "$RACKET_VERSION" = 6.[0-4]* ]]; then
     URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket-${RACKET_VERSION}-x86_64-linux-ubuntu-precise.sh"
+elif [[ "$RACKET_VERSION" = 6.* ]]; then
+    URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket-${RACKET_VERSION}-x86_64-linux.sh"
 else
     URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket/racket-${RACKET_VERSION}-bin-x86_64-linux-debian-squeeze.sh"
 fi


### PR DESCRIPTION
This addresses #14 by adding a new case for versions 6.0 through 6.4 and adding a new fallthrough case for 6.5+.