### PR TITLE
Overhaul install-racket.sh and add test.sh to validate full matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
     - RACKET_VERSION=6.1.1
     - RACKET_VERSION=6.2
     - RACKET_VERSION=HEAD
-    - RACKET_VERSION=SCOPE_SNAPSHOT
     - RACKET_VERSION=RELEASE
 
 # You may want to test against certain versions of Racket, without
@@ -38,7 +37,6 @@ env:
 matrix:
   allow_failures:
     - env: RACKET_VERSION=HEAD
-    - env: RACKET_VERSION=SCOPE_SNAPSHOT
     - env: RACKET_VERSION=RELEASE
   # Fast finish: Overall build result is determined as soon as any of
   # its rows have failed, or, all of its rows that aren't allowed to

--- a/install-racket.sh
+++ b/install-racket.sh
@@ -3,20 +3,46 @@
 
 set -e
 
-if [[ "$RACKET_VERSION" = "HEAD" ]]; then
-    URL="http://plt.eecs.northwestern.edu/snapshots/current/installers/racket-test-current-x86_64-linux-precise.sh"
-elif [[ "$RACKET_VERSION" = "SCOPE_SNAPSHOT" ]]; then
-    URL="http://www.cs.utah.edu/~mflatt/tmp/scope-snapshot/installers/racket-current-x86_64-linux.sh"
-elif [[ "$RACKET_VERSION" = "RELEASE" ]]; then
-    URL="http://pre-release.racket-lang.org/installers/racket-current-x86_64-linux.sh"
-elif [[ "$RACKET_VERSION" = 5.9* ]]; then
-    URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket-${RACKET_VERSION}-x86_64-linux-ubuntu-quantal.sh"
-elif [[ "$RACKET_VERSION" = 6.[0-4]* ]]; then
-    URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket-${RACKET_VERSION}-x86_64-linux-ubuntu-precise.sh"
-elif [[ "$RACKET_VERSION" = 6.* ]]; then
-    URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket-${RACKET_VERSION}-x86_64-linux.sh"
+if [[ "$RACKET_MINIMAL" = "1" ]]; then
+    MIN="minimal-"
 else
-    URL="http://download.racket-lang.org/installers/${RACKET_VERSION}/racket/racket-${RACKET_VERSION}-bin-x86_64-linux-debian-squeeze.sh"
+    MIN=""
+fi
+
+DL_BASE="http://download.racket-lang.org/installers"
+
+if [[ "$RACKET_VERSION" = "HEAD" ]]; then
+    if [[ "$RACKET_MINIMAL" = "1" ]]; then
+        URL="http://plt.eecs.northwestern.edu/snapshots/current/installers/min-racket-current-x86_64-linux-precise.sh"
+    else
+        URL="http://plt.eecs.northwestern.edu/snapshots/current/installers/racket-test-current-x86_64-linux-precise.sh"
+    fi
+elif [[ "$RACKET_VERSION" = 5.3* ]]; then
+    if [[ "$RACKET_MINIMAL" = "1" ]]; then
+        URL="${DL_BASE}/${RACKET_VERSION}/racket-textual/racket-textual-${RACKET_VERSION}-bin-x86_64-linux-debian-squeeze.sh"
+    else
+        URL="${DL_BASE}/${RACKET_VERSION}/racket/racket-${MIN}${RACKET_VERSION}-bin-x86_64-linux-debian-squeeze.sh"
+    fi
+elif [[ "$RACKET_VERSION" = "RELEASE" ]]; then
+    URL="http://pre-release.racket-lang.org/installers/racket-${MIN}current-x86_64-linux.sh"
+elif [[ "$RACKET_VERSION" = 5.9* ]]; then
+    URL="${DL_BASE}/${RACKET_VERSION}/racket-${MIN}${RACKET_VERSION}-x86_64-linux-ubuntu-quantal.sh"
+elif [[ "$RACKET_VERSION" = 6.[0-4]* ]]; then
+    URL="${DL_BASE}/${RACKET_VERSION}/racket-${MIN}${RACKET_VERSION}-x86_64-linux-ubuntu-precise.sh"
+elif [[ "$RACKET_VERSION" = 6.* ]]; then
+    URL="${DL_BASE}/${RACKET_VERSION}/racket-${MIN}${RACKET_VERSION}-x86_64-linux.sh"
+else
+    echo "ERROR: Unsupported version ${RACKET_VERSION}"
+    exit 1
+fi
+
+if [ -n "$TEST" ]; then
+    printf "%s %-7s %-120s " $RACKET_MINIMAL $RACKET_VERSION $URL
+    if curl -I -L $URL 2>&1 | grep 404.Not.Found ; then
+        exit 1
+    fi
+    echo "GOOD"
+    exit 0
 fi
 
 # Older .travis.yml files don't set $RACKET_DIR (the Racket install
@@ -25,7 +51,7 @@ if [[ "$RACKET_DIR" = "" ]]; then
     RACKET_DIR=/usr/racket
 fi
 
-INSTALLER="./racket-${RACKET_VERSION}.sh"
+INSTALLER="./racket-${MIN}${RACKET_VERSION}.sh"
 
 echo "Downloading $URL to $INSTALLER:"
 curl -L -o $INSTALLER $URL
@@ -47,5 +73,10 @@ no
 "$RACKET_DIR"
 
 EOF
+
+if [[ "$RACKET_MINIMAL" = "1" ]]; then
+    echo "Minimal Racket: Installing packages for raco test..."
+    ${RACKET_DIR}/bin/raco pkg install --auto --scope installation rackunit-lib compiler-lib
+fi
 
 exit 0

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+for VER in 6.6 6.5 6.4 6.3 6.2 6.2.1 6.1 6.1.1 6.0 6.0.1 5.93 5.92 5.3 5.3.6 5.3.5 5.3.4 5.3.3 5.3.2 5.3.1 HEAD RELEASE ; do
+    for MIN in 0 1; do
+        TEST=1 RACKET_MINIMAL=$MIN RACKET_VERSION=$VER ./install-racket.sh
+    done
+done


### PR DESCRIPTION
Namely, added test.sh to run through all the possible downloads and test for validity.

Added handler for TEST=1 in install-racket.sh.

Normalize urls as much as possible and to get minimal installs working
properly. This can probably be merged to master and drop the minimal
branch entirely.

I think there is still some cleanup that can happen. The various linux
flavors can probably be unified, if not parameterized.

This patch removes SCOPE_SNAPSHOT, as it seems to point to incredibly
stale content. RELEASE does too, but there is a note that it is only
valid during release phases.