### PR TITLE
Add support for v7.0 Beta

### DIFF
--- a/install-racket.sh
+++ b/install-racket.sh
@@ -25,6 +25,8 @@ elif [[ "$RACKET_VERSION" = 5.3* ]]; then
     fi
 elif [[ "$RACKET_VERSION" = "RELEASE" ]]; then
     URL="http://pre-release.racket-lang.org/installers/racket-${MIN}current-x86_64-linux.sh"
+elif [[ "$RACKET_VERSION" = "BETA7.0" ]]; then
+    URL="http://pre-release.racket-lang.org/installers/racket-${MIN}6.90.0.901-x86_64-linux.sh"
 elif [[ "$RACKET_VERSION" = 5.9* ]]; then
     URL="${DL_BASE}/${RACKET_VERSION}/racket-${MIN}${RACKET_VERSION}-x86_64-linux-ubuntu-quantal.sh"
 elif [[ "$RACKET_VERSION" = 6.[0-4] ]] || [[ "$RACKET_VERSION" = 6.[0-4].[0-9] ]]; then


### PR DESCRIPTION
I choose 

    RACKET_VERSION = BETA7.0

but there are other possibilities like `7.0.BETA` or just `BETA`.

I prefer `BETA7.0` so all the special builds start with a letter instead of a number.