### PR TITLE
Fix the plt.eecs URL to use https for builds with HEAD

### DIFF
--- a/install-racket.sh
+++ b/install-racket.sh
@@ -12,10 +12,11 @@ fi
 DL_BASE="https://mirror.racket-lang.org/installers"
 
 if [[ "$RACKET_VERSION" = "HEAD" ]]; then
+    NWU_BASE="http://plt.eecs.northwestern.edu/snapshots/current/installers"
     if [[ "$RACKET_MINIMAL" = "1" ]]; then
-        URL="http://plt.eecs.northwestern.edu/snapshots/current/installers/min-racket-current-x86_64-linux-precise.sh"
+        URL="${NWU_BASE}/min-racket-current-x86_64-linux-precise.sh"
     else
-        URL="http://plt.eecs.northwestern.edu/snapshots/current/installers/racket-test-current-x86_64-linux-precise.sh"
+        URL="${NWU_BASE}/racket-test-current-x86_64-linux-precise.sh"
     fi
 elif [[ "$RACKET_VERSION" = 5.3* ]]; then
     if [[ "$RACKET_MINIMAL" = "1" ]]; then

--- a/install-racket.sh
+++ b/install-racket.sh
@@ -12,7 +12,7 @@ fi
 DL_BASE="https://mirror.racket-lang.org/installers"
 
 if [[ "$RACKET_VERSION" = "HEAD" ]]; then
-    NWU_BASE="http://plt.eecs.northwestern.edu/snapshots/current/installers"
+    NWU_BASE="https://plt.eecs.northwestern.edu/snapshots/current/installers"
     if [[ "$RACKET_MINIMAL" = "1" ]]; then
         URL="${NWU_BASE}/min-racket-current-x86_64-linux-precise.sh"
     else


### PR DESCRIPTION
Travis tests on HEAD of Racket were failing because `plt.eecs.northwestern.edu` returned a `301` ("moved permanently") error if you didn't have the `https` prefix.