### PR TITLE
Support Racket-on-Chez snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
     - RACKET_VERSION=6.12
     - RACKET_VERSION=7.0
     - RACKET_VERSION=HEAD
+    - RACKET_VERSION=HEADCS
     - RACKET_VERSION=RELEASE
 
 # You may want to test against certain versions of Racket, without

--- a/install-racket.sh
+++ b/install-racket.sh
@@ -18,6 +18,13 @@ if [[ "$RACKET_VERSION" = "HEAD" ]]; then
     else
         URL="${NWU_BASE}/racket-test-current-x86_64-linux-precise.sh"
     fi
+elif [[ "$RACKET_VERSION" = "HEADCS" ]]; then
+    UTAH_BASE="https://www.cs.utah.edu/plt/snapshots/current/installers"
+    if [[ "$RACKET_MINIMAL" = "1" ]]; then
+	URL="${UTAH_BASE}/min-racket-current-x86_64-linux-cs-xenial.sh"
+    else
+	URL="${UTAH_BASE}/racket-current-x86_64-linux-cs-xenial.sh"
+    fi
 elif [[ "$RACKET_VERSION" = 5.3* ]]; then
     if [[ "$RACKET_MINIMAL" = "1" ]]; then
         URL="${DL_BASE}/${RACKET_VERSION}/racket-textual/racket-textual-${RACKET_VERSION}-bin-x86_64-linux-debian-squeeze.sh"


### PR DESCRIPTION
This pull request adds a `RACKET_VERSION` of `HEADCS` to use the new Racket-on-Chez snapshots from Utah. (Northwestern doesn't seem to be building them.)

Note that the Travis tests for this pull request will, ironically, fail, because `.travis.yml` uses the upstream master of `install-racket.sh`, and it doesn't know about `HEADCS` without this pull request. I have tested that the change to `install-racket.sh` works by using my fork in one of my own Travis builds.

Two considerations that might (or might not) weigh against merging this:

- I don't know what the long-term future of the Racket-on-Chez snapshots is, e.g. after Racket-on-Chez becomes just "Racket". On the other hand, we could cross that bridge when we come to it: maybe we would treat `HEADCS` like `HEAD`, or it might actually be more friendly to fail with a nice error message so people know to remove the redundant case from their build matrices.

- In the project I used to test this, I found that, with Racket-on-Chez, the `raco pkg install` step was getting killed by Travis, [apparently](https://docs.travis-ci.com/user/common-build-problems/#my-build-script-is-killed-without-any-error) because too many parallel workers were exhausting the memory available. I could solve this by using `-j 2` (I haven't tried `-j 4`, but the Travis docs suggest that might also be safe).
If these issues seem to be common with Racket-on-Chez and aren't likely to be fixed by improvements to the implementation, maybe the example `.travis.yml` file should include reasonable workarounds. On the other hand, I don't know how we'd determine what changes might be needed without more people getting some experience trying to build against Racket-on-Chez.