### PR TITLE
Use shallow git clone instead of full git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,9 @@ matrix:
 
 
 before_install:
-  - git clone https://github.com/greghendershott/travis-racket.git
+  # Repo history and other branches aren't useful here, so do a shallow clone
+  # to only download the tip of the master branch of the repo.
+  - git clone --depth 1 https://github.com/greghendershott/travis-racket.git
   - cat travis-racket/install-racket.sh | bash # pipe to bash not sh!
   - export PATH="${RACKET_DIR}/bin:${PATH}" #install-racket.sh can't set for us
 


### PR DESCRIPTION
Since the repo history is never used, I figured it makes more sense to just do a shallow clone of this repo in the `.travis.yml` file. It saves a whopping 34% of disk space after download! Ok, so it was only 141k in the first place; it wasn't _that_ much of a savings 🙄 . Still, 93k < 141k, and as more commits accrue over time the difference in saved bandwidth/disk space versus pulling down the whole repo will only increase.