### PR TITLE
Non-cs version is not available from https://www.cs.utah.edu/ for 8.0

### DIFF
--- a/install-racket.sh
+++ b/install-racket.sh
@@ -45,6 +45,7 @@ fi
 # it work.
 
 DL_BASE="https://www.cs.utah.edu/plt/installers"
+MIRROR_DL_BASE="https://mirror.racket-lang.org/installers"
 
 # In theory either NWU or Utah should work for downloading snapshot
 # a.k.a. HEAD builds. In practice, it varies from time to time.
@@ -82,7 +83,7 @@ elif [[ "$RACKET_VERSION" = 6.* ]]; then
 elif [[ "$RACKET_VERSION" = 7.* ]]; then
     URL="${DL_BASE}/${RACKET_VERSION}/racket-${MIN}${RACKET_VERSION}-x86_64-linux${RACKET_NATIPKG}${RACKET_CS}.sh"
 elif [[ "$RACKET_VERSION" = 8.* ]]; then
-    URL="${DL_BASE}/${RACKET_VERSION}/racket-${MIN}${RACKET_VERSION}-x86_64-linux${RACKET_NATIPKG}${RACKET_CS}.sh"
+    URL="${MIRROR_DL_BASE}/${RACKET_VERSION}/racket-${MIN}${RACKET_VERSION}-x86_64-linux${RACKET_NATIPKG}${RACKET_CS}.sh"
 else
     echo "ERROR: Unsupported version ${RACKET_VERSION}"
     exit 1


### PR DESCRIPTION
Hi!

This is an addendum to #39, sorry about the double-MR, I hadn't realised that some files were missing on the https://www.cs.utah.edu/ version.

I checked that it works with RACKET_CS=1 and without (https://travis-ci.org/github/jsmaniac/delay-pure) so there shouldn't be any further modifications needed :)